### PR TITLE
Added reverse compatibility with DSM 5.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,12 @@ Installation
 
 Usage
 =====
+Constructor::
+
+        SynologyDSM(dsm_ip, dsm_port, username, password,
+                    use_https=False, debugmode=False, dsm_version=6)
+
+``dsm_version = 5 will use old DSM API to gather volumes and disks informations (from DSM 5.x versions)``
 
 Module
 ------
@@ -50,6 +56,7 @@ You can import the module as `SynologyDSM`.
         print("Temp:       " + str(api.storage.disk_temp(disk)))
       
 Credits / Special Thanks
-=====
+========================
 - https://github.com/florianeinfalt
 - https://github.com/tchellomello
+- https://github.com/aaska

--- a/SynologyDSM/SynologyDSM.py
+++ b/SynologyDSM/SynologyDSM.py
@@ -373,7 +373,7 @@ class SynologyDSM():
     #pylint: disable=too-many-arguments,too-many-instance-attributes
     """Class containing the main Synology DSM functions"""
     def __init__(self, dsm_ip, dsm_port, username, password,
-                 use_https=False, debugmode=False, dsmVersion="6.x"):
+                 use_https=False, debugmode=False, dsm_version=6):
         # Store Variables
         self.username = username
         self.password = password
@@ -390,7 +390,7 @@ class SynologyDSM():
         self._session = None
 
         # adding DSM Version
-        self._dsmVersion = dsmVersion
+        self._dsm_version = dsm_version
 
 
         # Build Variables
@@ -403,7 +403,7 @@ class SynologyDSM():
         else:
             self.base_url = "http://%s:%s/webapi" % (dsm_ip, dsm_port)
         
-        if self._dsmVersion == "5.x":
+        if self._dsm_version == 5:
             if self._use_https:
                 self.storage_url = "https://%s:%s/webman/modules/StorageManager/storagehandler.cgi" % (dsm_ip, dsm_port)
             else: 
@@ -530,7 +530,7 @@ class SynologyDSM():
                 self.access_token)
             self._utilisation.update(self._get_url(url))
         if self._storage is not None:
-            if self._dsmVersion != "5.x":
+            if self._dsm_version != 5:
                 api = "SYNO.Storage.CGI.Storage"
                 url = "%s/entry.cgi?api=%s&version=1&method=load_info&_sid=%s" % (
                     self.base_url,
@@ -561,21 +561,19 @@ class SynologyDSM():
     def storage(self):
         """Getter for various Storage variables"""
         if self._storage is None:
-            if self._dsmVersion != "5.x":
+            if self._dsm_version != 5:
                 api = "SYNO.Storage.CGI.Storage"
                 url = "%s/entry.cgi?api=%s&version=1&method=load_info" % (
                     self.base_url,
                     api)
-                # self._storage = SynoStorage(self._get_url(url))
             else:
                 url = "%s?action=load_info" % (self.storage_url)
 
             output = self._get_url(url)
-            if self._dsmVersion != "5.x":
+            if self._dsm_version != 5:
                 self._storage = SynoStorage(output)
             else:
                 output["data"] = output
-                last_output = SynoStorage(output)
-                self._storage = last_output
+                self._storage = SynoStorage(output)
 
         return self._storage

--- a/SynologyDSM/SynologyDSM.py
+++ b/SynologyDSM/SynologyDSM.py
@@ -373,7 +373,7 @@ class SynologyDSM():
     #pylint: disable=too-many-arguments,too-many-instance-attributes
     """Class containing the main Synology DSM functions"""
     def __init__(self, dsm_ip, dsm_port, username, password,
-                 use_https=False, debugmode=False):
+                 use_https=False, debugmode=False, dsmVersion="6.x"):
         # Store Variables
         self.username = username
         self.password = password
@@ -389,6 +389,10 @@ class SynologyDSM():
         self._session_error = False
         self._session = None
 
+        # adding DSM Version
+        self._dsmVersion = dsmVersion
+
+
         # Build Variables
         if self._use_https:
             # https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
@@ -398,6 +402,13 @@ class SynologyDSM():
             self.base_url = "https://%s:%s/webapi" % (dsm_ip, dsm_port)
         else:
             self.base_url = "http://%s:%s/webapi" % (dsm_ip, dsm_port)
+        
+        if self._dsmVersion == "5.x":
+            if self._use_https:
+                self.storage_url = "https://%s:%s/webman/modules/StorageManager/storagehandler.cgi" % (dsm_ip, dsm_port)
+            else: 
+                self.storage_url = "http://%s:%s/webman/modules/StorageManager/storagehandler.cgi" % (dsm_ip, dsm_port)
+
     #pylint: enable=too-many-arguments,too-many-instance-attributes
 
     def _debuglog(self, message):
@@ -519,12 +530,21 @@ class SynologyDSM():
                 self.access_token)
             self._utilisation.update(self._get_url(url))
         if self._storage is not None:
-            api = "SYNO.Storage.CGI.Storage"
-            url = "%s/entry.cgi?api=%s&version=1&method=load_info&_sid=%s" % (
-                self.base_url,
-                api,
-                self.access_token)
-            self._storage.update(self._get_url(url))
+            if self._dsmVersion != "5.x":
+                api = "SYNO.Storage.CGI.Storage"
+                url = "%s/entry.cgi?api=%s&version=1&method=load_info&_sid=%s" % (
+                    self.base_url,
+                    api,
+                    self.access_token)
+                self._storage.update(self._get_url(url))
+            else:
+                url = "%s?action=load_info&_sid=%s" % (
+                    self.storage_url,
+                    self.access_token)
+                output = self._get_url(url)
+                output["data"] = output
+                self._storage.update(output)
+
 
     @property
     def utilisation(self):
@@ -541,9 +561,21 @@ class SynologyDSM():
     def storage(self):
         """Getter for various Storage variables"""
         if self._storage is None:
-            api = "SYNO.Storage.CGI.Storage"
-            url = "%s/entry.cgi?api=%s&version=1&method=load_info" % (
-                self.base_url,
-                api)
-            self._storage = SynoStorage(self._get_url(url))
+            if self._dsmVersion != "5.x":
+                api = "SYNO.Storage.CGI.Storage"
+                url = "%s/entry.cgi?api=%s&version=1&method=load_info" % (
+                    self.base_url,
+                    api)
+                # self._storage = SynoStorage(self._get_url(url))
+            else:
+                url = "%s?action=load_info" % (self.storage_url)
+
+            output = self._get_url(url)
+            if self._dsmVersion != "5.x":
+                self._storage = SynoStorage(output)
+            else:
+                output["data"] = output
+                last_output = SynoStorage(output)
+                self._storage = last_output
+
         return self._storage


### PR DESCRIPTION
I don't know very much Python, but I've adapted the class to add compatibility with DSM 5.x versions.

My code seems very dirty, but basically it has a different endpoint to retrieve volumes and disks data on 5.x and the class needs to be updated as there is no root data object in the previous endpoint.

Let me know if you need any additional information